### PR TITLE
Fix unused AnimationType

### DIFF
--- a/src/components/StoryPage.tsx
+++ b/src/components/StoryPage.tsx
@@ -45,7 +45,7 @@ const animationVariants = {
 }
 
 export function StoryPage({ page, isActive, className }: StoryPageProps) {
-  const animation = page.animation || 'fadeIn'
+  const animation: AnimationType = page.animation ?? 'fadeIn'
   const variant = animationVariants[animation]
 
   if (!isActive) return null


### PR DESCRIPTION
## Summary
- fix unused variable warning by annotating `animation`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685f5e5060448324a461e82cc24d1330