### PR TITLE
Add env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ cd ugoku-ehon-app
 # 依存関係をインストール
 npm install
 
+# API キーの設定
+プロジェクトルートに `.env` ファイルを作成し、以下のように API キーを設定します。
+
+```bash
+echo "OPENAI_API_KEY=your_api_key_here" > .env
+```
+
 # 開発サーバーを起動
 npm run dev
 ```


### PR DESCRIPTION
## Summary
- allow `.env` to be tracked
- add example `.env` file with an API key placeholder
- document how to create `.env` in the README
- rename API_KEY to OPENAI_API_KEY

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f674741ec8324b3f0b4104f76f408