### PR TITLE
Add OpenAI based image generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "framer-motion": "^12.19.2",
     "lucide-react": "^0.525.0",
     "next": "15.3.4",
+    "openai": "^4.20.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-dropzone": "^14.3.8",

--- a/src/app/api/generate-images/route.ts
+++ b/src/app/api/generate-images/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+import OpenAI from 'openai'
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData()
+  const image = formData.get('image') as File | null
+  const story = formData.get('story') as string | null
+
+  if (!image || !story) {
+    return NextResponse.json({ error: 'Missing image or story' }, { status: 400 })
+  }
+
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+
+  const prompt = `${story}\nIllustrate this scene for a children's picture book. The main character should resemble the uploaded child photo.`
+
+  try {
+    const res = await openai.images.generate({
+      model: 'dall-e-3',
+      prompt,
+      n: 4,
+      size: '1024x1024'
+    })
+
+    const urls = res.data.map(d => d.url)
+
+    return NextResponse.json({ urls })
+  } catch (error) {
+    console.error(error)
+    return NextResponse.json({ error: 'Failed to generate images' }, { status: 500 })
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { StoryViewer } from '@/components/StoryViewer'
+import { ImageUpload } from '@/components/ImageUpload'
 import { useStore } from '@/store/useStore'
 import type { Story } from '@/types'
 
@@ -36,27 +37,96 @@ function generateSampleStory(): Story {
 }
 
 export default function HomePage() {
-  const { currentStory, setCurrentStory } = useStore()
+  const [storyText, setStoryText] = useState('')
+  const {
+    currentStory,
+    setCurrentStory,
+    uploadedImages,
+    isGenerating,
+    setIsGenerating
+  } = useStore()
 
   const handleCreate = useCallback(() => {
     const story = generateSampleStory()
     setCurrentStory(story)
   }, [setCurrentStory])
 
+  const handleGenerate = useCallback(async () => {
+    if (!uploadedImages.child || !storyText.trim()) return
+
+    setIsGenerating(true)
+    const formData = new FormData()
+    formData.append('image', uploadedImages.child)
+    formData.append('story', storyText)
+
+    const res = await fetch('/api/generate-images', {
+      method: 'POST',
+      body: formData
+    })
+
+    if (!res.ok) {
+      setIsGenerating(false)
+      return
+    }
+
+    const data = await res.json()
+    const urls: string[] = data.urls || []
+    const lines = storyText.split('\n').filter(Boolean)
+    const id = Date.now().toString()
+    const pages = urls.map((url, i) => ({
+      id: `${id}-${i}`,
+      text: lines[i] || '',
+      imageUrl: url,
+      animation: 'fadeIn' as const
+    }))
+
+    const story: Story = {
+      id,
+      title: 'AI絵本',
+      childName: 'child',
+      createdAt: new Date(),
+      pages
+    }
+
+    setCurrentStory(story)
+    setIsGenerating(false)
+  }, [uploadedImages.child, storyText, setCurrentStory, setIsGenerating])
+
   if (currentStory) {
     return <StoryViewer className="h-screen" />
   }
 
   return (
-    <div style={{ padding: '20px', backgroundColor: '#f0f0f0', minHeight: '100vh' }}>
+    <div
+      style={{ padding: '20px', backgroundColor: '#f0f0f0', minHeight: '100vh' }}
+    >
       <h1 style={{ color: '#333', fontSize: '32px', marginBottom: '20px' }}>
         動く絵本アプリ
       </h1>
       <p style={{ color: '#666', fontSize: '18px', marginBottom: '20px' }}>
         子ども向けの動きのあるイラスト付き絵本をWebアプリとして提供するサービスです。
       </p>
+
+      <div style={{ marginBottom: '20px' }}>
+        <ImageUpload type="child" />
+      </div>
+
+      <textarea
+        value={storyText}
+        onChange={(e) => setStoryText(e.target.value)}
+        rows={4}
+        placeholder="1行ずつ4ページ分の物語を入力してください"
+        style={{
+          width: '100%',
+          padding: '8px',
+          marginBottom: '20px',
+          borderRadius: '6px'
+        }}
+      />
+
       <button
-        onClick={handleCreate}
+        onClick={handleGenerate}
+        disabled={isGenerating}
         style={{
           backgroundColor: '#8B5CF6',
           color: 'white',
@@ -64,11 +134,29 @@ export default function HomePage() {
           border: 'none',
           borderRadius: '8px',
           fontSize: '16px',
-          cursor: 'pointer'
+          cursor: 'pointer',
+          opacity: isGenerating ? 0.6 : 1
         }}
       >
-        絵本を作る
+        {isGenerating ? '生成中...' : '絵本を生成'}
       </button>
+
+      <div style={{ marginTop: '40px' }}>
+        <button
+          onClick={handleCreate}
+          style={{
+            backgroundColor: '#aaa',
+            color: 'white',
+            padding: '8px 16px',
+            border: 'none',
+            borderRadius: '6px',
+            fontSize: '14px',
+            cursor: 'pointer'
+          }}
+        >
+          サンプルを表示
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add OpenAI dependency
- create an API route to generate images using the OpenAI API
- update the home page with an uploader and text field to request four pictures from OpenAI

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7f25f67c8324ad1df32c8d7d51e5