### PR TITLE
Fix type check in image generator

### DIFF
--- a/src/app/api/generate-images/route.ts
+++ b/src/app/api/generate-images/route.ts
@@ -22,7 +22,7 @@ export async function POST(req: NextRequest) {
       size: '1024x1024'
     })
 
-    const urls = res.data.map(d => d.url)
+    const urls = (res.data ?? []).map(d => d.url)
 
     return NextResponse.json({ urls })
   } catch (error) {


### PR DESCRIPTION
## Summary
- handle optional data when reading image URLs from OpenAI response

## Testing
- `npm ci` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685f8070eb448324ad247b96131865e7