### PR TITLE
Add debug logs for picture book generation

### DIFF
--- a/src/app/api/generate-images/route.ts
+++ b/src/app/api/generate-images/route.ts
@@ -26,7 +26,8 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ urls })
   } catch (error) {
-    console.error(error)
-    return NextResponse.json({ error: 'Failed to generate images' }, { status: 500 })
+    console.error('generate-images error:', error)
+    const message = error instanceof Error ? error.message : 'Failed to generate images'
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }


### PR DESCRIPTION
## Summary
- show detailed logs during picture book generation
- display server error messages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f86c2ed04832490400f3c543a4b15