### PR TITLE
Switch image generation to single result

### DIFF
--- a/src/app/api/generate-images/route.ts
+++ b/src/app/api/generate-images/route.ts
@@ -18,7 +18,7 @@ export async function POST(req: NextRequest) {
     const res = await openai.images.generate({
       model: 'dall-e-3',
       prompt,
-      n: 4,
+      n: 1,
       size: '1024x1024'
     })
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -140,8 +140,8 @@ export default function HomePage() {
       <textarea
         value={storyText}
         onChange={(e) => setStoryText(e.target.value)}
-        rows={4}
-        placeholder="1行ずつ4ページ分の物語を入力してください"
+        rows={1}
+        placeholder="1行の物語を入力してください"
         style={{
           width: '100%',
           padding: '8px',


### PR DESCRIPTION
## Summary
- update API to request one generated image
- change text input to single line to match single image

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8b4ed7908324b9bb6b149e8fbb6c