### PR TITLE
Improve OpenAI error handling

### DIFF
--- a/src/app/api/generate-images/route.ts
+++ b/src/app/api/generate-images/route.ts
@@ -10,7 +10,12 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Missing image or story' }, { status: 400 })
   }
 
-  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey) {
+    return NextResponse.json({ error: 'OpenAI API key not configured' }, { status: 500 })
+  }
+
+  const openai = new OpenAI({ apiKey })
 
   const prompt = `${story}\nIllustrate this scene for a children's picture book. The main character should resemble the uploaded child photo.`
 
@@ -27,6 +32,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ urls })
   } catch (error) {
     console.error('generate-images error:', error)
+    if (error instanceof OpenAI.APIError) {
+      const message = error.error?.message || error.message
+      return NextResponse.json({ error: message }, { status: error.status })
+    }
     const message = error instanceof Error ? error.message : 'Failed to generate images'
     return NextResponse.json({ error: message }, { status: 500 })
   }


### PR DESCRIPTION
## Summary
- handle missing API key and OpenAI errors in generate-images API

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8e0de23c83249c618d5908218b5a