### PR TITLE
Implement face overlay for picture book

### DIFF
--- a/src/app/api/generate-images/route.ts
+++ b/src/app/api/generate-images/route.ts
@@ -17,7 +17,7 @@ export async function POST(req: NextRequest) {
 
   const openai = new OpenAI({ apiKey })
 
-  const prompt = `${story}\nIllustrate this scene for a children's picture book. The main character should resemble the uploaded child photo.`
+  const prompt = `${story}\nIllustrate this scene for a children's picture book. The main character should resemble the uploaded child photo. Place the protagonist's face at the center of the image and cut out the face area so it is transparent.`
 
   try {
     const res = await openai.images.generate({

--- a/src/components/StoryPage.tsx
+++ b/src/components/StoryPage.tsx
@@ -9,6 +9,7 @@ interface StoryPageProps {
   page: StoryPageType
   isActive: boolean
   className?: string
+  overlayImageUrl?: string
 }
 
 const animationVariants = {
@@ -44,7 +45,7 @@ const animationVariants = {
   }
 }
 
-export function StoryPage({ page, isActive, className }: StoryPageProps) {
+export function StoryPage({ page, isActive, className, overlayImageUrl }: StoryPageProps) {
   const animation: AnimationType = page.animation ?? 'fadeIn'
   const variant = animationVariants[animation]
 
@@ -85,14 +86,26 @@ export function StoryPage({ page, isActive, className }: StoryPageProps) {
       {/* Illustration Area */}
       <div className="flex-1 flex items-center justify-center mb-6 w-full max-w-md">
         {page.imageUrl ? (
-          <motion.img
-            src={page.imageUrl}
-            alt={`Story illustration for: ${page.text}`}
-            className="max-w-full max-h-full object-contain rounded-lg shadow-lg"
-            initial={{ scale: 0.9, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            transition={{ delay: 0.2, duration: 0.4 }}
-          />
+          <div className="relative">
+            <motion.img
+              src={page.imageUrl}
+              alt={`Story illustration for: ${page.text}`}
+              className="max-w-full max-h-full object-contain rounded-lg shadow-lg"
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ delay: 0.2, duration: 0.4 }}
+            />
+            {overlayImageUrl && (
+              <motion.img
+                src={overlayImageUrl}
+                alt="overlay"
+                className="absolute inset-0 m-auto w-1/2 h-1/2 object-cover"
+                initial={{ scale: 0.9, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                transition={{ delay: 0.2, duration: 0.4 }}
+              />
+            )}
+          </div>
         ) : (
           <motion.div
             className="w-full h-64 bg-gradient-to-br from-pink-100 to-purple-100 rounded-lg shadow-lg flex items-center justify-center"

--- a/src/components/StoryViewer.tsx
+++ b/src/components/StoryViewer.tsx
@@ -14,12 +14,13 @@ interface StoryViewerProps {
 }
 
 export function StoryViewer({ className }: StoryViewerProps) {
-  const { 
-    currentStory, 
-    currentPageIndex, 
-    nextPage, 
-    previousPage, 
-    setCurrentStory 
+  const {
+    currentStory,
+    currentPageIndex,
+    nextPage,
+    previousPage,
+    setCurrentStory,
+    uploadedImages
   } = useStore()
 
   if (!currentStory) {
@@ -33,6 +34,17 @@ export function StoryViewer({ className }: StoryViewerProps) {
   const progress = ((currentPageIndex + 1) / currentStory.pages.length) * 100
   const canGoNext = currentPageIndex < currentStory.pages.length - 1
   const canGoPrevious = currentPageIndex > 0
+
+  const overlayImageUrl = React.useMemo(() => {
+    if (!uploadedImages.child) return undefined
+    return URL.createObjectURL(uploadedImages.child)
+  }, [uploadedImages.child])
+
+  React.useEffect(() => {
+    return () => {
+      if (overlayImageUrl) URL.revokeObjectURL(overlayImageUrl)
+    }
+  }, [overlayImageUrl])
 
   const handleKeyPress = (event: React.KeyboardEvent) => {
     if (event.key === 'ArrowRight' && canGoNext) {
@@ -83,6 +95,7 @@ export function StoryViewer({ className }: StoryViewerProps) {
             page={currentStory.pages[currentPageIndex]}
             isActive={true}
             className="absolute inset-0"
+            overlayImageUrl={overlayImageUrl}
           />
         </AnimatePresence>
       </div>


### PR DESCRIPTION
## Summary
- instruct DALL·E prompt to output a centered transparent face cutout
- overlay uploaded photo over generated image in `StoryPage`
- handle uploaded photo URL and pass to pages via `StoryViewer`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f933e3a9883249592d5163fc9e3e1