### PR TITLE
Add central face prompt and show circular preview

### DIFF
--- a/src/app/api/generate-images/route.ts
+++ b/src/app/api/generate-images/route.ts
@@ -17,7 +17,7 @@ export async function POST(req: NextRequest) {
 
   const openai = new OpenAI({ apiKey })
 
-  const prompt = `${story}\nIllustrate this scene for a children's picture book. The main character should resemble the uploaded child photo. Place the protagonist's face at the center of the image and cut out the face area so it is transparent.`
+  const prompt = `${story}\nIllustrate this scene for a children's picture book. The main character should resemble the uploaded child photo. Place the protagonist's face at the center of the image.`
 
   try {
     const res = await openai.images.generate({


### PR DESCRIPTION
## Summary
- update DALL·E prompt so generated images put the hero's face in the center
- add `cropImageToCircle` helper
- generate a circular preview of the first DALL·E image
- show that preview on the home page with a button to view the story

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f985bec9483249749bd914bdddc7a