### PR TITLE
Fix summary width

### DIFF
--- a/src/components/StoryPage.tsx
+++ b/src/components/StoryPage.tsx
@@ -125,7 +125,7 @@ export function StoryPage({ page, isActive, className, overlayImageUrl }: StoryP
 
       {/* Text Area */}
       <motion.div
-        className="w-full max-w-lg"
+        className="w-full max-w-md sm:max-w-lg md:max-w-xl lg:max-w-2xl"
         initial={{ y: 20, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ delay: 0.4, duration: 0.4 }}


### PR DESCRIPTION
## Summary
- widen synopsis area with responsive max-width breakpoints

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa96807448324b04044d3ede8c593