### PR TITLE
Update overlay mask to reveal child image

### DIFF
--- a/src/components/StoryPage.tsx
+++ b/src/components/StoryPage.tsx
@@ -4,12 +4,13 @@ import React from 'react'
 import { motion } from 'framer-motion'
 import { StoryPage as StoryPageType, AnimationType } from '@/types'
 import { cn } from '@/lib/utils'
+import { createDalleOverlay } from '@/lib/image'
 
 interface StoryPageProps {
   page: StoryPageType
   isActive: boolean
   className?: string
-  overlayImageUrl?: string
+  childImageUrl?: string
 }
 
 const animationVariants = {
@@ -45,9 +46,27 @@ const animationVariants = {
   }
 }
 
-export function StoryPage({ page, isActive, className, overlayImageUrl }: StoryPageProps) {
+export function StoryPage({ page, isActive, className, childImageUrl }: StoryPageProps) {
   const animation: AnimationType = page.animation ?? 'fadeIn'
   const variant = animationVariants[animation]
+
+  const [overlayUrl, setOverlayUrl] = React.useState<string>()
+
+  React.useEffect(() => {
+    let cancelled = false
+    if (!page.imageUrl) {
+      setOverlayUrl(undefined)
+      return
+    }
+    createDalleOverlay(page.imageUrl)
+      .then((url) => {
+        if (!cancelled) setOverlayUrl(url)
+      })
+      .catch(() => setOverlayUrl(undefined))
+    return () => {
+      cancelled = true
+    }
+  }, [page.imageUrl])
 
   if (!isActive) return null
 
@@ -87,24 +106,24 @@ export function StoryPage({ page, isActive, className, overlayImageUrl }: StoryP
       <div className="flex-1 flex items-center justify-center mb-6 w-full max-w-md">
         {page.imageUrl ? (
           <div className="relative">
-            <motion.img
-              src={page.imageUrl}
-              alt={`Story illustration for: ${page.text}`}
-              className="max-w-full max-h-full object-contain rounded-lg shadow-lg"
-              initial={{ scale: 0.9, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              transition={{ delay: 0.2, duration: 0.4 }}
-            />
-            {overlayImageUrl && (
+            {childImageUrl && (
               <motion.img
-                src={overlayImageUrl}
-                alt="overlay"
+                src={childImageUrl}
+                alt="child"
                 className="absolute inset-0 m-auto w-full h-full object-contain pointer-events-none"
                 initial={{ scale: 0.9, opacity: 0 }}
                 animate={{ scale: 1, opacity: 1 }}
                 transition={{ delay: 0.2, duration: 0.4 }}
               />
             )}
+            <motion.img
+              src={overlayUrl || page.imageUrl}
+              alt={`Story illustration for: ${page.text}`}
+              className="max-w-full max-h-full object-contain rounded-lg shadow-lg"
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ delay: 0.2, duration: 0.4 }}
+            />
           </div>
         ) : (
           <motion.div

--- a/src/components/StoryViewer.tsx
+++ b/src/components/StoryViewer.tsx
@@ -24,19 +24,19 @@ export function StoryViewer({ className }: StoryViewerProps) {
     uploadedImages
   } = useStore()
 
-  const [overlayImageUrl, setOverlayImageUrl] = React.useState<string>()
+  const [childImageUrl, setChildImageUrl] = React.useState<string>()
 
   React.useEffect(() => {
     let cancelled = false
     if (!uploadedImages.child) {
-      setOverlayImageUrl(undefined)
+      setChildImageUrl(undefined)
       return
     }
     createCompositeImage(uploadedImages.child)
       .then((url) => {
-        if (!cancelled) setOverlayImageUrl(url)
+        if (!cancelled) setChildImageUrl(url)
       })
-      .catch(() => setOverlayImageUrl(undefined))
+      .catch(() => setChildImageUrl(undefined))
     return () => {
       cancelled = true
     }
@@ -103,7 +103,7 @@ export function StoryViewer({ className }: StoryViewerProps) {
             page={currentStory.pages[currentPageIndex]}
             isActive={true}
             className="absolute inset-0"
-            overlayImageUrl={overlayImageUrl}
+            childImageUrl={childImageUrl}
           />
         </AnimatePresence>
       </div>

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -8,6 +8,11 @@ export function loadImage(src: string): Promise<HTMLImageElement> {
   });
 }
 
+/**
+ * Resize the uploaded image to fit within a smaller square area in the centre
+ * of the canvas. The empty space around the image is kept transparent so that
+ * it can be combined with other layers later.
+ */
 export async function createCompositeImage(
   file: File,
   outputSize = 512,
@@ -26,28 +31,55 @@ export async function createCompositeImage(
     const ctx = canvas.getContext('2d');
     if (!ctx) throw new Error('canvas not supported');
 
-    ctx.drawImage(img, sx, sy, size, size, 0, 0, outputSize, outputSize);
+    const radius = (outputSize / 2 - margin) / 2;
+    const diameter = radius * 2;
+    const offset = (outputSize - diameter) / 2;
 
-    ctx.fillStyle = 'rgba(0,0,0,0.5)';
-    ctx.fillRect(0, 0, outputSize, outputSize);
-
-    const radius = outputSize / 2 - margin;
-
-    ctx.save();
-    ctx.globalCompositeOperation = 'destination-out';
-    ctx.beginPath();
-    ctx.arc(outputSize / 2, outputSize / 2, radius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.restore();
-
-    ctx.strokeStyle = 'white';
-    ctx.lineWidth = 8;
-    ctx.beginPath();
-    ctx.arc(outputSize / 2, outputSize / 2, radius - 4, 0, Math.PI * 2);
-    ctx.stroke();
+    ctx.drawImage(img, sx, sy, size, size, offset, offset, diameter, diameter);
 
     return canvas.toDataURL();
   } finally {
     URL.revokeObjectURL(tmpUrl);
   }
+}
+
+/**
+ * Create a version of the DALL-E image with a transparent circular hole in the
+ * centre. The surrounding area of the image remains intact so that the uploaded
+ * image placed underneath becomes visible only through the hole.
+ */
+export async function createDalleOverlay(
+  url: string,
+  outputSize = 512,
+  margin = 80
+): Promise<string> {
+  const img = await loadImage(url);
+  const size = Math.min(img.width, img.height);
+  const sx = (img.width - size) / 2;
+  const sy = (img.height - size) / 2;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = outputSize;
+  canvas.height = outputSize;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('canvas not supported');
+
+  ctx.drawImage(img, sx, sy, size, size, 0, 0, outputSize, outputSize);
+
+  const radius = (outputSize / 2 - margin) / 2;
+
+  ctx.save();
+  ctx.globalCompositeOperation = 'destination-out';
+  ctx.beginPath();
+  ctx.arc(outputSize / 2, outputSize / 2, radius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+
+  ctx.strokeStyle = 'white';
+  ctx.lineWidth = 8;
+  ctx.beginPath();
+  ctx.arc(outputSize / 2, outputSize / 2, radius - 4, 0, Math.PI * 2);
+  ctx.stroke();
+
+  return canvas.toDataURL();
 }


### PR DESCRIPTION
## Summary
- resize uploaded photo and keep transparent padding
- create DALL-E overlay with a circular hole
- pass processed child image through StoryViewer
- compute overlay per page and stack images accordingly

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685facd243488324ac469f047357504f