### PR TITLE
Remove unsupported DALL-E size option

### DIFF
--- a/src/app/api/generate-images/route.ts
+++ b/src/app/api/generate-images/route.ts
@@ -23,8 +23,7 @@ export async function POST(req: NextRequest) {
     const res = await openai.images.generate({
       model: 'dall-e-3',
       prompt,
-      n: 1,
-      size: '512x512'
+      n: 1
     })
 
     const url = res.data?.[0]?.url


### PR DESCRIPTION
## Summary
- remove 512x512 size option from image generation API

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fcfd1b8648324b3b10371782e580b