### PR TITLE
Update image generation API for GPT image model

### DIFF
--- a/src/app/api/generate-images/route.ts
+++ b/src/app/api/generate-images/route.ts
@@ -21,9 +21,11 @@ export async function POST(req: NextRequest) {
 
   try {
     const res = await openai.images.generate({
-      model: 'dall-e-3',
+      model: 'gpt-image-1',
       prompt,
-      n: 1
+      n: 1,
+      mode: 'image-to-image',
+      image
     })
 
     const url = res.data?.[0]?.url


### PR DESCRIPTION
## Summary
- modify the image generation route to use the `gpt-image-1` model
- pass uploaded photo to OpenAI for image-to-image generation

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe8087e6c8324bec45a36aea63482