### PR TITLE
Fix ESLint unused variable error

### DIFF
--- a/src/components/StoryViewer.tsx
+++ b/src/components/StoryViewer.tsx
@@ -19,8 +19,7 @@ export function StoryViewer({ className }: StoryViewerProps) {
     currentPageIndex,
     nextPage,
     previousPage,
-    setCurrentStory,
-    uploadedImages
+    setCurrentStory
   } = useStore()
 
 


### PR DESCRIPTION
## Summary
- remove the unused `uploadedImages` variable from `StoryViewer`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685fe9ebe71c8324afdc909bd7aceb71