### PR TITLE
Remove redundant mode flag

### DIFF
--- a/src/app/api/generate-images/route.ts
+++ b/src/app/api/generate-images/route.ts
@@ -29,7 +29,6 @@ export async function POST(req: NextRequest) {
       model: 'gpt-image-1',
       prompt,
       n: 1,
-      mode: 'image-to-image',
       image
     })
 


### PR DESCRIPTION
## Summary
- delete unused `mode` parameter from the image generation route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff2db6fe083249ad21c1056afbafe